### PR TITLE
[BEAR-4126]: (Health Sync) Added weight to new native code

### DIFF
--- a/RCTAppleHealthKit.xcodeproj/project.pbxproj
+++ b/RCTAppleHealthKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		377D44F31D247D0A004E35CB /* RCTAppleHealthKit+Methods_Characteristic.m in Sources */ = {isa = PBXBuildFile; fileRef = 377D44F21D247D0A004E35CB /* RCTAppleHealthKit+Methods_Characteristic.m */; };
 		37837E7D1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m in Sources */ = {isa = PBXBuildFile; fileRef = 37837E7C1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m */; };
 		4F8095C92523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F8095C82523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m */; };
+		54325B0F2CAADA9700346FB7 /* BucketedWeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B0E2CAADA9700346FB7 /* BucketedWeight.swift */; };
 		54500EB52C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m in Sources */ = {isa = PBXBuildFile; fileRef = 54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */; };
 		548E95692C8B3FB100464ABA /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548E95682C8B3FB100464ABA /* Helpers.swift */; };
 		549AC6452C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549AC6442C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift */; };
@@ -71,6 +72,7 @@
 		37837E7C1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_Sleep.m"; sourceTree = "<group>"; };
 		4F8095C72523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit+Methods_LabTests.h"; sourceTree = "<group>"; };
 		4F8095C82523C39D00A84ADB /* RCTAppleHealthKit+Methods_LabTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+Methods_LabTests.m"; sourceTree = "<group>"; };
+		54325B0E2CAADA9700346FB7 /* BucketedWeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedWeight.swift; sourceTree = "<group>"; };
 		54500EB02C89ECF200B03A3E /* RCTAppleHealthKit-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit-Bridging-Header.h"; sourceTree = "<group>"; };
 		54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+BucketedQueries.m"; sourceTree = "<group>"; };
 		548E95682C8B3FB100464ABA /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				549AC6462C91B4B5005B8517 /* BucketedSteps.swift */,
 				549AC6492C91B789005B8517 /* BucketedHeartRate.swift */,
 				549AC64B2C91B8EA005B8517 /* BucketedQueryType.swift */,
+				54325B0E2CAADA9700346FB7 /* BucketedWeight.swift */,
 			);
 			path = BucketedQueries;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 			files = (
 				3774C89B1D2095450000B3F3 /* RCTAppleHealthKit+Queries.m in Sources */,
 				3774C8A11D20A6B90000B3F3 /* RCTAppleHealthKit+Utils.m in Sources */,
+				54325B0F2CAADA9700346FB7 /* BucketedWeight.swift in Sources */,
 				8C640F40269DF69C004CAFED /* RCTAppleHealthKit+Methods_Hearing.m in Sources */,
 				37837E7D1DCFE270000201A0 /* RCTAppleHealthKit+Methods_Sleep.m in Sources */,
 				3774C8D41D20C6390000B3F3 /* RCTAppleHealthKit+Methods_Body.m in Sources */,

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRate.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRate.swift
@@ -18,7 +18,12 @@ class BucketedHeartRate: BucketedQueryType {
         return [.discreteAverage, .discreteMax, .discreteMin]
     }
     
-    func statisticsValue(statistic: HKStatistics) -> String? {
+    func statisticsUnit(unitString: String?) -> HKUnit {
+        // Beats per minute
+        return .count().unitDivided(by: HKUnit.minute())
+    }
+    
+    func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {
         guard let average = statistic.averageQuantity() else {
             return nil
         }
@@ -29,10 +34,9 @@ class BucketedHeartRate: BucketedQueryType {
             return nil
         }
         
-        let beatsPerMinuteUnit = HKUnit.count().unitDivided(by: HKUnit.minute())
-        let averageValue = average.doubleValue(for: beatsPerMinuteUnit)
-        let maximumValue = maximum.doubleValue(for: beatsPerMinuteUnit)
-        let minimumValue = minimum.doubleValue(for: beatsPerMinuteUnit)
+        let averageValue = average.doubleValue(for: unit)
+        let maximumValue = maximum.doubleValue(for: unit)
+        let minimumValue = minimum.doubleValue(for: unit)
         
         let averageString = formatDoubleAsString(value: averageValue)
         let maximumString = formatDoubleAsString(value: maximumValue)

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedQueryType.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedQueryType.swift
@@ -12,5 +12,6 @@ protocol BucketedQueryType {
 
     func quantityType() -> HKQuantityType?
     func queryOptions() -> HKStatisticsOptions
-    func statisticsValue(statistic: HKStatistics) -> String?
+    func statisticsUnit(unitString: String?) -> HKUnit
+    func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String?
 }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
@@ -1,5 +1,5 @@
 //
-//  Steps.swift
+//  BucketedWeight.swift
 //  RCTAppleHealthKit
 //
 //  Copyright © 2024 Bearable. All rights reserved.
@@ -7,23 +7,30 @@
 
 import Foundation
 
-class BucketedSteps: BucketedQueryType {
-    var recordType: RecordType = .steps
+class BucketedWeight: BucketedQueryType {
+    var recordType: RecordType = .weight
     
     func quantityType() -> HKQuantityType? {
-        return HKObjectType.quantityType(forIdentifier: .stepCount)
+        return HKObjectType.quantityType(forIdentifier: .bodyMass)
     }
     
     func queryOptions() -> HKStatisticsOptions {
-        return .cumulativeSum
+        return .discreteAverage
     }
     
     func statisticsUnit(unitString: String?) -> HKUnit {
-        return .count()
+        switch unitString {
+        case "pound":
+            return .pound()
+        case "kg":
+            return HKUnit(from: "kg")
+        default:
+            return HKUnit(from: "kg")
+        }
     }
     
     func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {
-        if let quantity = statistic.sumQuantity() {
+        if let quantity = statistic.averageQuantity() {
             let value = quantity.doubleValue(for: unit)
             return formatDoubleAsString(value: value)
         }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
@@ -37,6 +37,7 @@ import HealthKit
         }
 
         let queryOptions = queryType.queryOptions()
+        let unit = queryType.statisticsUnit(unitString: unitFromOptions(options: options, key: "unit"))
         let interval = intervalFromOptions(options: options, key: "bucketPeriod")
         let end = dateFromOptions(options: options, key: "endTime")
         let predicate = createPredicate(from: start, to: end)
@@ -72,7 +73,7 @@ import HealthKit
             let records: NSMutableArray = []
             // Loop over all the statistics objects
             for statistics in statsCollection.statistics() {
-                guard let value = queryType.statisticsValue(statistic: statistics) else {
+                guard let value = queryType.statisticsValue(statistic: statistics, unit: unit) else {
                     continue
                 }
 

--- a/RCTAppleHealthKit/Swift/Constants.swift
+++ b/RCTAppleHealthKit/Swift/Constants.swift
@@ -12,4 +12,5 @@ let RECORDS_FAMILY = "health"
 enum RecordType: String {
     case steps = "STEPS"
     case heart = "HEART"
+    case weight = "WEIGHT"
 }

--- a/RCTAppleHealthKit/Swift/Helpers.swift
+++ b/RCTAppleHealthKit/Swift/Helpers.swift
@@ -29,6 +29,13 @@ func dateFromOptions(options: NSDictionary, key: String) -> Date? {
     return nil
 }
 
+func unitFromOptions(options: NSDictionary, key: String) -> String? {
+    if let unitString = options[key] as? String {
+        return unitString
+    }
+    return nil
+}
+
 func intervalFromOptions(options: NSDictionary, key: String) -> DateComponents {
     if let intervalString = options[key] as? String {
         // switch string to DateComponents
@@ -54,6 +61,8 @@ func queryTypeFromRecordType(recordType: String) -> BucketedQueryType? {
         return BucketedSteps()
     case RecordType.heart:
         return BucketedHeartRate()
+    case RecordType.weight:
+        return BucketedWeight()
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -470,6 +470,7 @@ declare module 'react-native-health' {
         startTime: string
         endTime: string
         bucketPeriod: 'day' | 'month' | 'year'
+        unit?: HealthUnit
       },
     ): Promise<BucketedRecord[]>
 
@@ -477,7 +478,7 @@ declare module 'react-native-health' {
   }
 
   /* Bearable Types */
-  export type RecordType = 'STEPS' | 'HEART'
+  export type RecordType = 'STEPS' | 'HEART' | 'WEIGHT'
 
   export interface BucketedRecord {
     dateKey: string
@@ -849,6 +850,7 @@ declare module 'react-native-health' {
     inch = 'inch',
     joule = 'joule',
     kilocalorie = 'kilocalorie',
+    kg = 'kg',
     meter = 'meter',
     mgPerdL = 'mgPerdL',
     mile = 'mile',


### PR DESCRIPTION
## Description

I've added weight to be an available option to return the bearable specific data. I needed to allow the option to pass in a unit so that we can fetch the data based on the user preference. I haven't hooked this up to anything so it's safe to merge - the function will be used as part of [BEAR-4131](https://bearable-app.atlassian.net/browse/BEAR-4131). I added a new function in each query type so that we only calculate the unit once and not for every statistical value.

I'm manually switching between kg and pounds in the bearable code for the screen recording.

https://github.com/user-attachments/assets/51af87a8-cf38-45eb-8a8c-6939452986d1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [x] I have checked my code and corrected any misspellings


[BEAR-4131]: https://bearable-app.atlassian.net/browse/BEAR-4131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ