### PR TITLE
[BEAR-4125]: (Health Sync) Added blood pressure type and updated bucketed quantity function to handle multiple query types

### DIFF
--- a/RCTAppleHealthKit.xcodeproj/project.pbxproj
+++ b/RCTAppleHealthKit.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		54325B112CAAF64700346FB7 /* BucketedHeartRateVariability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B102CAAF64700346FB7 /* BucketedHeartRateVariability.swift */; };
 		54325B132CAAF79300346FB7 /* BucketedBodyTemperature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B122CAAF79200346FB7 /* BucketedBodyTemperature.swift */; };
 		54325B152CAAFA1300346FB7 /* BucketedRestingHeartRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */; };
+		54325B192CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */; };
+		54325B1B2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */; };
 		54500EB52C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m in Sources */ = {isa = PBXBuildFile; fileRef = 54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */; };
 		548E95692C8B3FB100464ABA /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548E95682C8B3FB100464ABA /* Helpers.swift */; };
 		549AC6452C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549AC6442C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift */; };
@@ -79,6 +81,8 @@
 		54325B102CAAF64700346FB7 /* BucketedHeartRateVariability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedHeartRateVariability.swift; sourceTree = "<group>"; };
 		54325B122CAAF79200346FB7 /* BucketedBodyTemperature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedBodyTemperature.swift; sourceTree = "<group>"; };
 		54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedRestingHeartRate.swift; sourceTree = "<group>"; };
+		54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedSystolicBloodPressure.swift; sourceTree = "<group>"; };
+		54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedDiastolicBloodPressure.swift; sourceTree = "<group>"; };
 		54500EB02C89ECF200B03A3E /* RCTAppleHealthKit-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit-Bridging-Header.h"; sourceTree = "<group>"; };
 		54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+BucketedQueries.m"; sourceTree = "<group>"; };
 		548E95682C8B3FB100464ABA /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -195,6 +199,8 @@
 				54325B102CAAF64700346FB7 /* BucketedHeartRateVariability.swift */,
 				54325B122CAAF79200346FB7 /* BucketedBodyTemperature.swift */,
 				54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */,
+				54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */,
+				54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */,
 			);
 			path = BucketedQueries;
 			sourceTree = "<group>";
@@ -259,6 +265,7 @@
 			files = (
 				54325B152CAAFA1300346FB7 /* BucketedRestingHeartRate.swift in Sources */,
 				3774C89B1D2095450000B3F3 /* RCTAppleHealthKit+Queries.m in Sources */,
+				54325B192CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift in Sources */,
 				3774C8A11D20A6B90000B3F3 /* RCTAppleHealthKit+Utils.m in Sources */,
 				54325B0F2CAADA9700346FB7 /* BucketedWeight.swift in Sources */,
 				8C640F40269DF69C004CAFED /* RCTAppleHealthKit+Methods_Hearing.m in Sources */,
@@ -281,6 +288,7 @@
 				548E95692C8B3FB100464ABA /* Helpers.swift in Sources */,
 				3774C89E1D2095850000B3F3 /* RCTAppleHealthKit+TypesAndPermissions.m in Sources */,
 				54B12B7F2C8F562400AD2C4C /* Errors.swift in Sources */,
+				54325B1B2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift in Sources */,
 				3774C8D71D20C65F0000B3F3 /* RCTAppleHealthKit+Methods_Fitness.m in Sources */,
 				549AC6472C91B4B5005B8517 /* BucketedSteps.swift in Sources */,
 				54500EB52C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m in Sources */,

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedBodyTemperature.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedBodyTemperature.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 class BucketedBodyTemperature: BucketedQueryType {
-    var recordType: RecordType = .bodyTemperature
-    
     func quantityType() -> HKQuantityType? {
         return HKObjectType.quantityType(forIdentifier: .bodyTemperature)
     }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedDiastolicBloodPressure.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedDiastolicBloodPressure.swift
@@ -1,5 +1,5 @@
 //
-//  BucketedRestingHeartRate.swift
+//  BucketedDiastolicBloodPressure.swift
 //  RCTAppleHealthKit
 //
 //  Copyright © 2024 Bearable. All rights reserved.
@@ -7,10 +7,9 @@
 
 import Foundation
 
-@available(iOS 11.0, *)
-class BucketedRestingHeartRate: BucketedQueryType {
+class BucketedDiastolicBloodPressure: BucketedQueryType {
     func quantityType() -> HKQuantityType? {
-        return HKObjectType.quantityType(forIdentifier: .restingHeartRate)
+        return HKObjectType.quantityType(forIdentifier: .bloodPressureDiastolic)
     }
     
     func queryOptions() -> HKStatisticsOptions {
@@ -18,8 +17,7 @@ class BucketedRestingHeartRate: BucketedQueryType {
     }
     
     func statisticsUnit(unitString: String?) -> HKUnit {
-        // Beats per minute
-        return .count().unitDivided(by: HKUnit.minute())
+        return HKUnit(from: "mmHg")
     }
     
     func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRate.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRate.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 class BucketedHeartRate: BucketedQueryType {
-    var recordType: RecordType = .heart
-    
     func quantityType() -> HKQuantityType? {
         return HKObjectType.quantityType(forIdentifier: .heartRate)
     }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRateVariability.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedHeartRateVariability.swift
@@ -9,8 +9,6 @@ import Foundation
 
 @available(iOS 11.0, *)
 class BucketedHeartRateVariability: BucketedQueryType {
-    var recordType: RecordType = .hrv
-    
     func quantityType() -> HKQuantityType? {
         return HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)
     }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedQueryType.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedQueryType.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 protocol BucketedQueryType {
-    var recordType: RecordType { get }
-
     func quantityType() -> HKQuantityType?
     func queryOptions() -> HKStatisticsOptions
     func statisticsUnit(unitString: String?) -> HKUnit

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSteps.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSteps.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 class BucketedSteps: BucketedQueryType {
-    var recordType: RecordType = .steps
-    
     func quantityType() -> HKQuantityType? {
         return HKObjectType.quantityType(forIdentifier: .stepCount)
     }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSystolicBloodPressure.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSystolicBloodPressure.swift
@@ -1,5 +1,5 @@
 //
-//  BucketedRestingHeartRate.swift
+//  BucketedSystolicBloodPressure.swift
 //  RCTAppleHealthKit
 //
 //  Copyright © 2024 Bearable. All rights reserved.
@@ -7,10 +7,9 @@
 
 import Foundation
 
-@available(iOS 11.0, *)
-class BucketedRestingHeartRate: BucketedQueryType {
+class BucketedSystolicBloodPressure: BucketedQueryType {
     func quantityType() -> HKQuantityType? {
-        return HKObjectType.quantityType(forIdentifier: .restingHeartRate)
+        return HKObjectType.quantityType(forIdentifier: .bloodPressureSystolic)
     }
     
     func queryOptions() -> HKStatisticsOptions {
@@ -18,8 +17,7 @@ class BucketedRestingHeartRate: BucketedQueryType {
     }
     
     func statisticsUnit(unitString: String?) -> HKUnit {
-        // Beats per minute
-        return .count().unitDivided(by: HKUnit.minute())
+        return HKUnit(from: "mmHg")
     }
     
     func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
@@ -8,14 +8,12 @@
 import Foundation
 
 class BucketedWeight: BucketedQueryType {
-    var recordType: RecordType = .weight
-    
     func quantityType() -> HKQuantityType? {
         return HKObjectType.quantityType(forIdentifier: .bodyMass)
     }
     
     func queryOptions() -> HKStatisticsOptions {
-        return .discreteAverage
+        return .mostRecent
     }
     
     func statisticsUnit(unitString: String?) -> HKUnit {
@@ -30,7 +28,7 @@ class BucketedWeight: BucketedQueryType {
     }
     
     func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {
-        if let quantity = statistic.averageQuantity() {
+        if let quantity = statistic.mostRecentQuantity() {
             let value = quantity.doubleValue(for: unit)
             return formatDoubleAsString(value: value)
         }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
@@ -23,7 +23,8 @@ import HealthKit
             return
         }
 
-        guard let queryType = queryTypeFromRecordType(recordType: recordType) else {
+        // Make into array
+        guard let queryTypes = queryTypeFromRecordType(recordType: recordType) else {
             reject(INVALID_OPTIONS_ERROR, "No matching record type for '\(recordType)'", nil)
             return
         }
@@ -31,61 +32,114 @@ import HealthKit
             reject(INVALID_OPTIONS_ERROR, "Start date must be provided", nil)
             return
         }
-        guard let quantityType = queryType.quantityType() else {
-            reject(UNEXPECTED_ERROR, "No matching quantity type to \(recordType)", nil)
-            return
-        }
 
-        let queryOptions = queryType.queryOptions()
-        let unit = queryType.statisticsUnit(unitString: unitFromOptions(options: options, key: "unit"))
         let interval = intervalFromOptions(options: options, key: "bucketPeriod")
         let end = dateFromOptions(options: options, key: "endTime")
         let predicate = createPredicate(from: start, to: end)
-
-        let query = HKStatisticsCollectionQuery(quantityType: quantityType,
-                                     quantitySamplePredicate: predicate,
-                                                     options: queryOptions,
-                                                  anchorDate: start,
-                                          intervalComponents: interval)
         
-        // Handle query results
-        query.initialResultsHandler = { query, results, error in
-            // Handle errors here.
-            if let error = error as? HKError {
-            switch (error.code) {
-            case .errorDatabaseInaccessible:
-                reject(UNEXPECTED_ERROR, "HealthKit couldn't access the database because the device is locked.", error)
-                // HealthKit couldn't access the database because the device is locked.
-                return
-            default:
-                reject(UNEXPECTED_ERROR, "\(error)", error)
-                // Handle other HealthKit errors here.
-                return
-            }
-            }
+        let dispatchGroup = DispatchGroup()
+        var queryTypeError: (message: String, error: Error?)?
         
-            guard let statsCollection = results else {
-                // You should only hit this case if you have an unhandled error. Check for bugs in your code that creates the query, or explicitly handle the error.
-                reject(UNEXPECTED_ERROR, "An error occurred fetching records for \(recordType)", nil)
+        var recordsDict: [String: [Int: String]] = [:]
+
+        for (index, queryType) in queryTypes.enumerated() {
+            dispatchGroup.enter()
+
+            guard let quantityType = queryType.quantityType() else {
+                queryTypeError = (
+                    message: "No matching quantity type to \(recordType)",
+                    error: nil
+                )
                 return
             }
+            
+            let queryOptions = queryType.queryOptions()
+            let unit = queryType.statisticsUnit(unitString: unitFromOptions(options: options, key: "unit"))
+            
+            let query = HKStatisticsCollectionQuery(quantityType: quantityType,
+                                         quantitySamplePredicate: predicate,
+                                                         options: queryOptions,
+                                                      anchorDate: start,
+                                              intervalComponents: interval)
 
+            query.initialResultsHandler = { query, results, error in
+                if let error = error as? HKError {
+                switch (error.code) {
+                case .errorDatabaseInaccessible:
+                    queryTypeError = (
+                        message: "HealthKit couldn't access the database because the device is locked.",
+                        error: error
+                    )
+                    // HealthKit couldn't access the database because the device is locked.
+                    return
+                default:
+                    queryTypeError = (
+                        message: "\(error)",
+                        error: error
+                    )
+                    // Handle other HealthKit errors here.
+                    return
+                }
+                }
+            
+                guard let statsCollection = results else {
+                    // You should only hit this case if you have an unhandled error. Check for bugs in your code that creates the query, or explicitly handle the error.
+                    queryTypeError = (
+                        message: "An error occurred fetching records for \(recordType)",
+                        error: nil
+                    )
+                    return
+                }
+
+                // Loop over all the statistics objects
+                for statistics in statsCollection.statistics() {
+                    // Add value to dictionary and do this in
+                    guard let value = queryType.statisticsValue(statistic: statistics, unit: unit) else {
+                        continue
+                    }
+                    
+                    let dateKey = formatDateKey(date: statistics.startDate)
+                    if recordsDict[dateKey] == nil {
+                        recordsDict[dateKey] = [:]
+                    }
+                    recordsDict[dateKey]?[index] = value
+                }
+                
+                dispatchGroup.leave()
+            }
+            
+            healthStore.execute(query)
+        
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            if let error = queryTypeError {
+                reject(UNEXPECTED_ERROR, error.message, error.error)
+                return
+            }
+            
             let records: NSMutableArray = []
-            // Loop over all the statistics objects
-            for statistics in statsCollection.statistics() {
-                guard let value = queryType.statisticsValue(statistic: statistics, unit: unit) else {
+            for (dateKey, values) in recordsDict {
+                if (values.count != queryTypes.count) {
                     continue
                 }
 
-                let record = formatRecord(date: statistics.startDate, type: queryType.recordType, value: value)
+                var value = ""
+                for (index, _) in queryTypes.enumerated() {
+                    if let queryString = values[index] {
+                        if !value.isEmpty {
+                            value += "/"
+                        }
+                        value += "\(queryString)"
+                    }
+                }
+
+                let record = formatRecord(date: dateKey, type: recordType, value: value)
                 records.add(record)
+                
             }
-            
-            DispatchQueue.main.async {
-                resolve(records)
-            }
+
+            resolve(records)
         }
-        
-        healthStore.execute(query)
     }
 }

--- a/RCTAppleHealthKit/Swift/Constants.swift
+++ b/RCTAppleHealthKit/Swift/Constants.swift
@@ -16,4 +16,5 @@ enum RecordType: String {
     case hrv = "HEART_RATE_VARIABILITY"
     case bodyTemperature = "BODY_TEMPERATURE"
     case restingHeart = "RESTING_HEART_RATE"
+    case bloodPressure = "PRESSURE"
 }

--- a/RCTAppleHealthKit/Swift/Helpers.swift
+++ b/RCTAppleHealthKit/Swift/Helpers.swift
@@ -52,24 +52,26 @@ func intervalFromOptions(options: NSDictionary, key: String) -> DateComponents {
 }
 
 @available(iOS 11.0, *)
-func queryTypeFromRecordType(recordType: String) -> BucketedQueryType? {
+func queryTypeFromRecordType(recordType: String) -> [BucketedQueryType]? {
     guard let recordTypeEnum = RecordType(rawValue: recordType.uppercased()) else {
         return nil
     }
 
     switch recordTypeEnum {
     case RecordType.steps:
-        return BucketedSteps()
+        return [BucketedSteps()]
     case RecordType.heart:
-        return BucketedHeartRate()
+        return [BucketedHeartRate()]
     case RecordType.weight:
-        return BucketedWeight()
+        return [BucketedWeight()]
     case RecordType.hrv:
-        return BucketedHeartRateVariability()
+        return [BucketedHeartRateVariability()]
     case RecordType.bodyTemperature:
-        return BucketedBodyTemperature()
+        return [BucketedBodyTemperature()]
     case RecordType.restingHeart:
-        return BucketedRestingHeartRate()
+        return [BucketedRestingHeartRate()]
+    case RecordType.bloodPressure:
+        return [BucketedSystolicBloodPressure(), BucketedDiastolicBloodPressure()]
     }
 }
 
@@ -89,12 +91,11 @@ func formatDoubleAsString(value: Double) -> String {
     return formatter.string(from: NSNumber(value: value)) ?? "0"
 }
 
-func formatRecord(date: Date, type: RecordType, value: String) -> NSDictionary {
-    let dateKey = formatDateKey(date: date)
+func formatRecord(date: String, type: String, value: String) -> NSDictionary {
     return [
-        "dateKey": dateKey,
+        "dateKey": date,
         "entry": [
-            "type": type.rawValue,
+            "type": type,
             "value": value,
             "family": RECORDS_FAMILY,
         ]


### PR DESCRIPTION
## Description

[🩸 Add new native function to get bucketed Blood Pressure](https://bearable-app.atlassian.net/browse/BEAR-4125)

I've added blood pressure as a query type however because it uses two quantity values I have amended the readBucketedQuantity to handle multiple query types. I think it would be a good one to walkthrough.

I've also updated the weight aggregation option as in the current sync we use the latest value, I have checked all the others are correct and that Julian is happy we use the average for heart rate variability.

https://github.com/user-attachments/assets/ad0305ff-f97f-4179-8004-cf1987b16e0b

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have checked my code and corrected any misspellings
