### PR TITLE
[BEAR-4127]: (Health Sync) Added new read bucketed sleep records

### DIFF
--- a/RCTAppleHealthKit.xcodeproj/project.pbxproj
+++ b/RCTAppleHealthKit.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		54325B152CAAFA1300346FB7 /* BucketedRestingHeartRate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */; };
 		54325B192CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */; };
 		54325B1B2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */; };
+		54325B1D2CADB4CA00346FB7 /* BucketedSleep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54325B1C2CADB4CA00346FB7 /* BucketedSleep.swift */; };
 		54500EB52C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m in Sources */ = {isa = PBXBuildFile; fileRef = 54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */; };
 		548E95692C8B3FB100464ABA /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 548E95682C8B3FB100464ABA /* Helpers.swift */; };
 		549AC6452C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549AC6442C91B09E005B8517 /* RCTAppleHealthKit+BucketedQueries.swift */; };
@@ -83,6 +84,7 @@
 		54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedRestingHeartRate.swift; sourceTree = "<group>"; };
 		54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedSystolicBloodPressure.swift; sourceTree = "<group>"; };
 		54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedDiastolicBloodPressure.swift; sourceTree = "<group>"; };
+		54325B1C2CADB4CA00346FB7 /* BucketedSleep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketedSleep.swift; sourceTree = "<group>"; };
 		54500EB02C89ECF200B03A3E /* RCTAppleHealthKit-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTAppleHealthKit-Bridging-Header.h"; sourceTree = "<group>"; };
 		54500EB42C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTAppleHealthKit+BucketedQueries.m"; sourceTree = "<group>"; };
 		548E95682C8B3FB100464ABA /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				54325B142CAAFA1300346FB7 /* BucketedRestingHeartRate.swift */,
 				54325B182CAC4D6700346FB7 /* BucketedSystolicBloodPressure.swift */,
 				54325B1A2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift */,
+				54325B1C2CADB4CA00346FB7 /* BucketedSleep.swift */,
 			);
 			path = BucketedQueries;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				3774C89E1D2095850000B3F3 /* RCTAppleHealthKit+TypesAndPermissions.m in Sources */,
 				54B12B7F2C8F562400AD2C4C /* Errors.swift in Sources */,
 				54325B1B2CAC4DEC00346FB7 /* BucketedDiastolicBloodPressure.swift in Sources */,
+				54325B1D2CADB4CA00346FB7 /* BucketedSleep.swift in Sources */,
 				3774C8D71D20C65F0000B3F3 /* RCTAppleHealthKit+Methods_Fitness.m in Sources */,
 				549AC6472C91B4B5005B8517 /* BucketedSteps.swift in Sources */,
 				54500EB52C8A0FB800B03A3E /* RCTAppleHealthKit+BucketedQueries.m in Sources */,

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSleep.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSleep.swift
@@ -1,0 +1,51 @@
+//
+//  BucketedSleep.swift
+//  RCTAppleHealthKit
+//
+//  Copyright © 2024 Bearable. All rights reserved.
+//
+
+import Foundation
+
+struct SleepValue {
+    var duration: Double
+    var inBed: Date?
+    var outOfBed: Date?
+    var fellAsleep: Date?
+    var wokeUp: Date?
+}
+
+@available(iOS 10.0, *)
+class BucketedSleep {
+    var recordType = "SLEEP"
+
+    func categoryType() -> HKCategoryType? {
+        return HKObjectType.categoryType(forIdentifier: .sleepAnalysis)
+    }
+    
+    func calculateSleepValue(sample: HKCategorySample, existingRecord: SleepValue?, cutoffHour: Int) -> SleepValue? {
+        let value = findSleepType(value: sample.value)
+        if value == .awake {
+            return nil
+        }
+        
+        let dateKey = formatSleepDateKey(date: sample.startDate, cutoff: cutoffHour)
+        var record = existingRecord ?? SleepValue(duration: 0, inBed: nil, outOfBed: nil, fellAsleep: nil, wokeUp: nil)
+
+        switch value {
+        case .inBed:
+            // Update inBed and outBed times with earliest and latest
+            record.inBed = record.inBed.map { min($0, sample.startDate) } ?? sample.startDate
+            record.outOfBed = record.outOfBed.map { max($0, sample.endDate) } ?? sample.endDate
+            
+        case .asleep:
+            // Update fellAsleep and wokeUp times with earliest and latest, increase duration
+            record.fellAsleep = record.fellAsleep.map { min($0, sample.startDate) } ?? sample.startDate
+            record.wokeUp = record.wokeUp.map { max($0, sample.endDate) } ?? sample.endDate
+            record.duration += sample.endDate.timeIntervalSince(sample.startDate)
+        default: break
+        }
+        
+        return record
+    }
+}

--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedWeight.swift
@@ -13,7 +13,11 @@ class BucketedWeight: BucketedQueryType {
     }
     
     func queryOptions() -> HKStatisticsOptions {
-        return .mostRecent
+        if #available(iOS 13.0, *) {
+            return .mostRecent
+        } else {
+            return .discreteAverage
+        }
     }
     
     func statisticsUnit(unitString: String?) -> HKUnit {
@@ -28,10 +32,18 @@ class BucketedWeight: BucketedQueryType {
     }
     
     func statisticsValue(statistic: HKStatistics, unit: HKUnit) -> String? {
-        if let quantity = statistic.mostRecentQuantity() {
-            let value = quantity.doubleValue(for: unit)
+        var quantity: HKQuantity?
+        if #available(iOS 13.0, *) {
+            quantity = statistic.mostRecentQuantity()
+        } else {
+            quantity = statistic.averageQuantity()
+        }
+        
+        if let unwrappedQuantity = quantity {
+            let value = unwrappedQuantity.doubleValue(for: unit)
             return formatDoubleAsString(value: value)
         }
+
         return nil
     }
 }

--- a/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.m
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.m
@@ -14,4 +14,8 @@ RCT_EXTERN_METHOD(readBucketedQuantity:recordType
                                resolve:(RCTPromiseResolveBlock)resolve
                                 reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(readBucketedSleep:options
+                               resolve:(RCTPromiseResolveBlock)resolve
+                                reject:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/RCTAppleHealthKit+BucketedQueries.swift
@@ -142,4 +142,79 @@ import HealthKit
             resolve(records)
         }
     }
+
+    @available(iOS 11.0, *)
+    @objc(readBucketedSleep:resolve:reject:)
+    func readBucketedSleep(
+        options: NSDictionary,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let healthStore = healthStore else {
+            reject(INIT_ERROR, INIT_ERROR_MESSAGE, nil)
+            return
+        }
+        
+        guard let start = dateFromOptions(options: options, key: "startTime") else {
+            reject(INVALID_OPTIONS_ERROR, "Start date must be provided", nil)
+            return
+        }
+
+        if intervalFromOptions(options: options, key: "bucketPeriod") != DateComponents(day: 1) {
+            reject(INVALID_OPTIONS_ERROR, "Bucket period is not supported - please use 'day'", nil)
+            return
+        }
+        
+        let end = dateFromOptions(options: options, key: "endTime")
+        let predicate = createPredicate(from: start, to: end)
+        
+        let bucketedSleep = BucketedSleep()
+        guard let categoryType = bucketedSleep.categoryType() else {
+            reject(UNEXPECTED_ERROR, "No matching category type to \(bucketedSleep.recordType)", nil)
+            return
+        }
+        
+        let query = HKSampleQuery(sampleType: categoryType, predicate: predicate, limit: Int(HKObjectQueryNoLimit), sortDescriptors: nil) {
+            query, results, error in
+            
+            guard let sleepSamples = results as? [HKCategorySample] else {
+                // Handle any errors here.
+                return
+            }
+
+            var recordsDict: [String: SleepValue] = [:]
+            let cutoffHour = Calendar.current.component(.hour, from: start)
+            
+            for sleepSample in sleepSamples {
+                let dateKey = formatSleepDateKey(date: sleepSample.startDate, cutoff: cutoffHour)
+                let sleepValue = bucketedSleep.calculateSleepValue(sample: sleepSample, existingRecord: recordsDict[dateKey], cutoffHour: cutoffHour)
+                if sleepValue == nil {
+                    continue // Skip awake samples
+                }
+
+                recordsDict[dateKey] = sleepValue
+            }
+            
+            print("RECORDS DICT")
+            print(recordsDict)
+            
+            let records: NSMutableArray = []
+            for (dateKey, sleepRecord) in recordsDict {
+                if sleepRecord.duration.isZero {
+                    continue
+                }
+                
+                records.add(formatSleepRecord(date: dateKey, type: bucketedSleep.recordType, sleepValue: sleepRecord))
+            }
+            
+            print("RECORDS ARRAY")
+            print(records)
+
+            DispatchQueue.main.async {
+                resolve(records)
+            }
+        }
+        
+        healthStore.execute(query)
+    }
 }

--- a/RCTAppleHealthKit/Swift/Constants.swift
+++ b/RCTAppleHealthKit/Swift/Constants.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let RECORDS_FAMILY = "health"
+let RECORDS_FAMILY = "HEALTH"
 
 enum RecordType: String {
     case steps = "STEPS"
@@ -17,4 +17,10 @@ enum RecordType: String {
     case bodyTemperature = "BODY_TEMPERATURE"
     case restingHeart = "RESTING_HEART_RATE"
     case bloodPressure = "PRESSURE"
+}
+
+enum SleepType {
+    case asleep
+    case inBed
+    case awake
 }

--- a/RCTAppleHealthKit/Swift/Helpers.swift
+++ b/RCTAppleHealthKit/Swift/Helpers.swift
@@ -16,6 +16,19 @@ func createPredicate(from: Date?, to: Date?) -> NSPredicate? {
     }
 }
 
+@available(iOS 10.0, *)
+func findSleepType(value: HKCategoryValueSleepAnalysis.RawValue) -> SleepType {
+    switch value {
+    case HKCategoryValueSleepAnalysis.inBed.rawValue:
+        return .inBed
+    case HKCategoryValueSleepAnalysis.awake.rawValue:
+        return .awake
+    // .asleepCore, .asleepREM, .asleepDeep, .asleepUnspecified
+    default:
+        return .asleep
+    }
+}
+
 // ----- Request Option Extraction Helpers ----- //
 
 @available(iOS 11.0, *)
@@ -83,12 +96,41 @@ func formatDateKey(date: Date) -> String {
     return dateFormatter.string(from: date)
 }
 
+func formatSleepDateKey(date: Date, cutoff: Int) -> String {
+    var finalDate = date
+
+    let sampleHour = Calendar.current.component(.hour, from: date)
+    if sampleHour > cutoff {
+        // If past the cutoff then we want to get the date key for the next day
+        finalDate = Calendar.current.date(byAdding: .day, value: 1, to: date)!
+    }
+    
+    return formatDateKey(date: finalDate)
+}
+
+// Format to YYYY-MM-DD HH:mm:ss.SSS as local time
+func formatLocalString(date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    formatter.timeZone = .current
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    return formatter.string(from: date)
+}
+
 func formatDoubleAsString(value: Double) -> String {
     let formatter = NumberFormatter()
     formatter.minimumFractionDigits = 0
     formatter.maximumFractionDigits = 2
 
     return formatter.string(from: NSNumber(value: value)) ?? "0"
+}
+
+func formatDuration(seconds: Double) -> String {
+    let hours = Int(seconds) / 3600
+    let secondsAfterHours = Int(seconds) % 3600
+    let minutes = secondsAfterHours / 60
+
+   return String(format: "%02d:%02d", hours, minutes)
 }
 
 func formatRecord(date: String, type: String, value: String) -> NSDictionary {
@@ -99,5 +141,43 @@ func formatRecord(date: String, type: String, value: String) -> NSDictionary {
             "value": value,
             "family": RECORDS_FAMILY,
         ]
+    ]
+}
+
+func formatSleepRecord(date: String, type: String, sleepValue: SleepValue) -> NSDictionary {
+    
+    let value = formatDuration(seconds: sleepValue.duration)
+
+    var entry: [String: Any] = [
+        "type": type,
+        "value": value,
+        "family": RECORDS_FAMILY,
+    ]
+    var timesInBed: [String: String] = [:]
+    var sleepTimes: [String: String] = [:]
+    
+    if let inBedAt = sleepValue.inBed {
+        timesInBed["inBedAt"] = formatLocalString(date: inBedAt)
+    }
+    if let outOfBedAt = sleepValue.outOfBed {
+        timesInBed["outOfBedAt"] = formatLocalString(date: outOfBedAt)
+    }
+    if let fellAsleepAt = sleepValue.fellAsleep {
+        sleepTimes["fellAsleepAt"] = formatLocalString(date: fellAsleepAt)
+    }
+    if let wokeUpAt = sleepValue.wokeUp {
+        sleepTimes["wokeUpAt"] = formatLocalString(date: wokeUpAt)
+    }
+    
+    if !timesInBed.isEmpty {
+        entry["timesInBed"] = timesInBed
+    }
+    if !sleepTimes.isEmpty {
+        entry["sleepTimes"] = sleepTimes
+    }
+    
+    return [
+        "dateKey": date,
+        "entry": entry
     ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -466,13 +466,12 @@ declare module 'react-native-health' {
 
     readBucketedQuantity(
       recordType: RecordType,
-      options: {
-        startTime: string
-        endTime: string
-        bucketPeriod: 'day' | 'month' | 'year'
-        unit?: HealthUnit
-      },
+      options: BucketedReadOptions,
     ): Promise<BucketedRecord[]>
+
+    readBucketedSleep(
+      options: BucketedReadOptions,
+    ): Promise<BucketedSleepRecord[]>
 
     Constants: Constants
   }
@@ -486,12 +485,36 @@ declare module 'react-native-health' {
     | 'RESTING_HEART_RATE'
     | 'BODY_TEMPERATURE'
 
+  export interface BucketedReadOptions {
+    startTime: string
+    endTime: string
+    bucketPeriod: 'day' | 'month' | 'year'
+    unit?: HealthUnit
+  }
+
   export interface BucketedRecord {
     dateKey: string
     entry: {
       type: string
       value: string
       family: string
+    }
+  }
+
+  export interface BucketedSleepRecord {
+    dateKey: string
+    entry: {
+      type: string
+      value: string
+      family: string
+      timesInBed: {
+        inBedAt: string
+        outOfBedAt: string
+      }
+      sleepTimes: {
+        fellAsleepAt: string
+        wokeUpAt: string
+      }
     }
   }
 


### PR DESCRIPTION
## Description

[😴 Add new native function to get bucketed sleep](https://bearable-app.atlassian.net/browse/BEAR-4127)

This adds the functionality to get the sleep data records structured in a way that bearable expects. I had to add a separate method as the sleep records are a Category type not a Quantity type which means we can't do statistical methods on them. I've set up the sleep class to keep it similar to the others and easy to spot. It's possible we can make this function more generic to category types similar to the quantity one however best to do that when we have more.

Since we can't query with statistic collections we have to get all sample data and process it ourselves. I've make sure of the following:
- We return the duration for the number of sleep hours added together based on the duration between samples, two sleeping samples should never overlap unless added wrong by the user manually to apple health
- We return the date in bed at from the earliest sample start date and the date out of bed from the latest end date
- We return the date fell asleep  from the earliest sample start date and the date woke up from the latest end date

I've also added a fix for the weight class as I was using a constant only available in ios 13 so I've defaulted to average.

I've checked that this is the same data as the original apple sync

https://github.com/user-attachments/assets/30034ad7-a3da-4eb3-9b35-de9b931b0c72

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] I have checked my code and corrected any misspellings
