### PR TITLE
[BEAR-4155]: (Health Sync) Update sleep to handle duration overlap

### DIFF
--- a/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSleep.swift
+++ b/RCTAppleHealthKit/Swift/BucketedQueries/BucketedSleep.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+struct SimpleSleepSample {
+    var startDate: Date
+    var endDate: Date
+    var type: SleepType
+}
+
 struct SleepValue {
     var duration: Double
     var inBed: Date?
@@ -23,27 +29,25 @@ class BucketedSleep {
         return HKObjectType.categoryType(forIdentifier: .sleepAnalysis)
     }
     
-    func calculateSleepValue(sample: HKCategorySample, existingRecord: SleepValue?, cutoffHour: Int) -> SleepValue? {
-        let value = findSleepType(value: sample.value)
-        if value == .awake {
-            return nil
-        }
-        
-        let dateKey = formatSleepDateKey(date: sample.startDate, cutoff: cutoffHour)
-        var record = existingRecord ?? SleepValue(duration: 0, inBed: nil, outOfBed: nil, fellAsleep: nil, wokeUp: nil)
+    func calculateSleepValue(samplesForDate: [SleepType: [SimpleSleepSample]]) -> SleepValue? {
+        var record = SleepValue(duration: 0, inBed: nil, outOfBed: nil, fellAsleep: nil, wokeUp: nil)
 
-        switch value {
-        case .inBed:
-            // Update inBed and outBed times with earliest and latest
-            record.inBed = record.inBed.map { min($0, sample.startDate) } ?? sample.startDate
-            record.outOfBed = record.outOfBed.map { max($0, sample.endDate) } ?? sample.endDate
-            
-        case .asleep:
-            // Update fellAsleep and wokeUp times with earliest and latest, increase duration
-            record.fellAsleep = record.fellAsleep.map { min($0, sample.startDate) } ?? sample.startDate
-            record.wokeUp = record.wokeUp.map { max($0, sample.endDate) } ?? sample.endDate
-            record.duration += sample.endDate.timeIntervalSince(sample.startDate)
-        default: break
+        for (value, samples) in samplesForDate {
+            for sample in samples {
+                switch value {
+                case .inBed:
+                    // Update inBed and outBed times with earliest and latest
+                    record.inBed = record.inBed.map { min($0, sample.startDate) } ?? sample.startDate
+                    record.outOfBed = record.outOfBed.map { max($0, sample.endDate) } ?? sample.endDate
+                    
+                case .asleep:
+                    // Update fellAsleep and wokeUp times with earliest and latest, increase duration
+                    record.fellAsleep = record.fellAsleep.map { min($0, sample.startDate) } ?? sample.startDate
+                    record.wokeUp = record.wokeUp.map { max($0, sample.endDate) } ?? sample.endDate
+                    record.duration += sample.endDate.timeIntervalSince(sample.startDate)
+                default: break
+                }
+            }
         }
         
         return record

--- a/RCTAppleHealthKit/Swift/Helpers.swift
+++ b/RCTAppleHealthKit/Swift/Helpers.swift
@@ -96,12 +96,12 @@ func formatDateKey(date: Date) -> String {
     return dateFormatter.string(from: date)
 }
 
-func formatSleepDateKey(date: Date, cutoff: Int) -> String {
+func formatSleepDateKey(date: Date, cutOff: Int) -> String {
     var finalDate = date
 
     let sampleHour = Calendar.current.component(.hour, from: date)
-    if sampleHour > cutoff {
-        // If past the cutoff then we want to get the date key for the next day
+    if sampleHour > cutOff {
+        // If past the cut off then we want to get the date key for the next day
         finalDate = Calendar.current.date(byAdding: .day, value: 1, to: date)!
     }
     


### PR DESCRIPTION
## Description

[😴 I don't want overlapping sleep times to be accounted for twice](https://bearable-app.atlassian.net/browse/BEAR-4155)

This handles the sleep samples when two different sleep types like REM or Deep sleep overlap and we don't want to count the duration twice.

I will update the bearable package as part of [BEAR-4166](https://bearable-app.atlassian.net/browse/BEAR-4166).

- [x] If a user has overlapping sleep data ie REM and Deep at the same time it should not duplicate the overlapping time. It should take the duration from the start time to the end time.

### Speed differences

<img width="300" src="https://github.com/user-attachments/assets/1862a56d-7f92-4299-b65c-78c98649f809">
<img width="300" src="https://github.com/user-attachments/assets/75604bd0-9e05-43b5-b360-65accf202a9c">
<img width="300" src="https://github.com/user-attachments/assets/58c678a2-3830-47e5-8fee-efc628f7de17">
<img width="300" src="https://github.com/user-attachments/assets/82daf635-5800-4933-817e-6fbd8d21d675">

### Data

<img width="300" src="https://github.com/user-attachments/assets/10197e84-7de3-4c58-970c-55076ba91e59">
<img width="300" src="https://github.com/user-attachments/assets/3a6b1291-5021-4fca-83b3-84fe436a8383">
<img width="300" src="https://github.com/user-attachments/assets/7fe395b1-9e79-4448-948c-6172320bc4a5">
<img width="300" src="https://github.com/user-attachments/assets/9d020087-80f5-4600-83da-ee326696b7be">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings


[BEAR-4166]: https://bearable-app.atlassian.net/browse/BEAR-4166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ