### PR TITLE
[BEAR-4223]: (Health sync) Un-pad sleep hours value

### DIFF
--- a/RCTAppleHealthKit/Swift/Helpers.swift
+++ b/RCTAppleHealthKit/Swift/Helpers.swift
@@ -130,7 +130,7 @@ func formatDuration(seconds: Double) -> String {
     let secondsAfterHours = Int(seconds) % 3600
     let minutes = secondsAfterHours / 60
 
-   return String(format: "%02d:%02d", hours, minutes)
+   return String(format: "%d:%02d", hours, minutes)
 }
 
 func formatRecord(date: String, type: String, value: String) -> NSDictionary {


### PR DESCRIPTION
## Description

[The sleep time has a 0 in front of single digit sleep hours when it shouldn't](https://bearable-app.atlassian.net/browse/BEAR-4223)

This removes the 0 pad at the start of the sleep value so instead of '07:15' it gives '7:15'.

<img width="200" alt="Screenshot 2024-10-10 at 18 11 33" src="https://github.com/user-attachments/assets/84467d54-081a-480c-bda4-9a33fbae2371">
<img width="200" alt="Screenshot 2024-10-10 at 18 11 38" src="https://github.com/user-attachments/assets/b6b95799-4dfa-4fef-9c77-6ef6de634d31">
<img width="200" alt="Screenshot 2024-10-10 at 18 11 49" src="https://github.com/user-attachments/assets/d5fac26c-d1e0-4dcf-9e8b-9c0036590bd6">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [x] I have checked my code and corrected any misspellings
